### PR TITLE
Top 5 rollovers increase the multiplier

### DIFF
--- a/comp/capture.p8
+++ b/comp/capture.p8
@@ -93,10 +93,7 @@ function check_collision_with_capture(
  _cap.timer=90
  _cap.reset_timer = 30
  _cap.bonus_timer = 0
- add_to_long(
-  score,
-  _cap.p*multiplier
- )
+ increase_score(_cap.p)
  if _cap.action != nil then
   _cap:action()
  end
@@ -168,9 +165,8 @@ function empty_fuel_action(_cap)
   _cnt+=tonum(_l.lit)
   _l.lit = false
  end
- add_to_long(
-  score,
-  _pnts[_cnt]*multiplier,
+ increase_score(
+  _pnts[_cnt],
   max(0,min(1,_cnt-3))
  )
 end

--- a/comp/rollover.p8
+++ b/comp/rollover.p8
@@ -9,7 +9,7 @@ function init_rollovers()
    create_rollover(52,19)
   },
   update=update_elem_group,
-  all_lit_action=rollovers_all_lit,
+  all_lit_action=increase_multi,
   rotatable=true,
   flash=0
  }
@@ -104,4 +104,9 @@ function rollovers_all_lit(_rg)
  for _r in all(_rg.elements) do
   set_light(_r,false)
  end
+end
+
+function increase_multi(_rg)
+ multiplier=min(4,multiplier+1)
+ rollovers_all_lit(_rg)
 end

--- a/comp/rollover.p8
+++ b/comp/rollover.p8
@@ -85,8 +85,8 @@ function check_collision_with_rollover(_r)
   return
  end
  set_light(_r,true)
- _r.reset_timer=60
- add_to_long(score,12500)
+ _r.reset_timer=20
+ increase_score(12500)
  if _r.action != nil then
    _r.action()
  end
@@ -100,7 +100,7 @@ end
 function rollovers_all_lit(_rg)
  -- action for when rollover
  -- group's lights all lit.
- add_to_long(score,150,1)
+ increase_score(150,1)
  for _r in all(_rg.elements) do
   set_light(_r,false)
  end

--- a/comp/round_bumper.p8
+++ b/comp/round_bumper.p8
@@ -39,7 +39,7 @@ function check_collision_with_r_bumper(_b,_pin)
  -- check for collision with the
  -- bumper
  if dist_between_vectors(_b.origin, _pin.origin)<=_b.r then
-  add_to_long(score,_b.p)
+  increase_score(_b.p)
   local normalized_perp_vec = normalize(subtract_vectors(_pin.origin,_b.origin))
   rollback_pinball_pos(_pin)
   _pin.spd = calc_reflection_vector(

--- a/comp/spinner.p8
+++ b/comp/spinner.p8
@@ -30,6 +30,6 @@ function update_spinner(_s)
  if _s.to_score > 0 then
   local scr_change = min(_s.to_score,max(25,flr(_s.to_score*0.02)))
   _s.to_score-=scr_change
-  add_to_long(score,scr_change*multiplier)
+  increase_score(scr_change)
  end
 end

--- a/comp/targets.p8
+++ b/comp/targets.p8
@@ -72,9 +72,9 @@ function check_collision_with_target(_obj,_pin)
  -- hits the target
  if check_collision_with_collider(_obj,_pin) then
   if _obj.lit then
-   add_to_long(score,200)
+   increase_score(200)
   else
-   add_to_long(score,500)
+   increase_score(500)
    _obj.lit=true
    _obj.spr_i=_obj.lit_spr
   end

--- a/lib/collision.p8
+++ b/lib/collision.p8
@@ -44,7 +44,7 @@ end
 function check_collision_with_collider(_obj,_pin)
  local _crossed_line = pin_entered_poly(_pin,_obj)
  if _crossed_line != nil then
-  add_to_long(score,_crossed_line.p or _obj.p or 0)
+  increase_score(_crossed_line.p or _obj.p or 0)
   rollback_pinball_pos(_pin)
   bounce_off_line(_pin,_crossed_line)
   return true

--- a/lib/increase_score.p8
+++ b/lib/increase_score.p8
@@ -1,0 +1,8 @@
+function increase_score(
+ _scr,_offset,_not_multi
+)
+ if not _not_multi then
+  _scr*=multiplier
+ end
+ add_to_long(score,_scr,_offset)
+end

--- a/modes/game.p8
+++ b/modes/game.p8
@@ -27,7 +27,7 @@ function init_game()
  tracker_cols={5,13}
  hits=0
 
- multiplier=2
+ multiplier=1
 
  draw_outlines=false
 end

--- a/terra-nova-pinball.p8
+++ b/terra-nova-pinball.p8
@@ -34,6 +34,8 @@ __lua__
 #include lib/pos_are_equal.p8
 #include lib/gen_simple_collider.p8
 #include lib/gen_collision_regions.p8
+#include lib/increase_score.p8
+
 -- common
 #include lib/common/2d_vectors.p8
 #include lib/common/mod_base_1.p8


### PR DESCRIPTION
Triggering the top 5 rollovers now increases the multiplier, which is correctly applied to all points scored on the table.